### PR TITLE
Fix ws DoS (CVE-2024-37890) in seriesFunc

### DIFF
--- a/server/seriesFunc/package-lock.json
+++ b/server/seriesFunc/package-lock.json
@@ -1,9 +1,12 @@
 {
-  "name": "seriesFunc",
+  "name": "series",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "series",
+      "version": "1.0.0",
       "dependencies": {
         "epub-gen": "^0.1.0",
         "puppeteer": "^22.11.1"
@@ -2131,9 +2134,10 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/server/seriesFunc/package.json
+++ b/server/seriesFunc/package.json
@@ -11,5 +11,8 @@
 	"dependencies": {
 		"epub-gen": "^0.1.0",
 		"puppeteer": "^22.11.1"
+	},
+	"overrides": {
+		"ws": "^8.17.1"
 	}
 }


### PR DESCRIPTION
Pins transitive `ws` to >=8.17.1 (resolves to 8.21.0) via an `overrides` block in server/seriesFunc, fixing the ws memory-exhaustion DoS Dependabot couldn't auto-fix here. Minimal diff — no other packages re-resolved. singleChapterFunc was already on 8.17.1; multiChapterFunc was fixed via a separate merged Dependabot PR.